### PR TITLE
fix: support any schema for a topic

### DIFF
--- a/kafka-commands.md
+++ b/kafka-commands.md
@@ -40,7 +40,6 @@ curl -X POST http://localhost:8901/apis/registry/v3/groups/com.acme.events/artif
     "artifactId": "UserAccessedShortenedUrl",
     "artifactType": "AVRO",
     "firstVersion": {
-        "version": "1",
         "content": {
             "content": "{\"type\":\"record\",\"name\":\"UserAccessedShortenedUrl\",\"namespace\":\"com.acme.events\",\"fields\":[{\"name\":\"unique_identifier\",\"type\":\"string\"},{\"name\":\"original_url\",\"type\":\"string\"},{\"name\":\"user_agent\",\"type\":\"string\"}]}",
             "contentType": "application/json"

--- a/myurlshortner-be/src/main/java/org/acme/application/kafka/KafkaUrlPublisherImpl.java
+++ b/myurlshortner-be/src/main/java/org/acme/application/kafka/KafkaUrlPublisherImpl.java
@@ -8,13 +8,13 @@ import org.acme.domain.ShortenedUrl;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.jspecify.annotations.NonNull;
 
-@IfBuildProfile(allOf = {"dev", "prod"})
+@IfBuildProfile(anyOf = {"dev", "prod"})
 @Singleton
 public class KafkaUrlPublisherImpl implements KafkaUrlPublisher {
     final MutinyEmitter<UserAccessedShortenedUrl> emitter;
 
     KafkaUrlPublisherImpl(
-            @Channel("shortened-url-events") MutinyEmitter<UserAccessedShortenedUrl> emitter
+            @Channel("user-accessed-shortened-url") MutinyEmitter<UserAccessedShortenedUrl> emitter
     ) {
         this.emitter = emitter;
     }

--- a/myurlshortner-be/src/main/java/org/acme/application/kafka/KafkaUrlPublisherLocal.java
+++ b/myurlshortner-be/src/main/java/org/acme/application/kafka/KafkaUrlPublisherLocal.java
@@ -1,6 +1,8 @@
 package org.acme.application.kafka;
 
 import io.quarkus.arc.DefaultBean;
+import io.quarkus.arc.profile.IfBuildProfile;
+import jakarta.enterprise.inject.Default;
 import jakarta.inject.Singleton;
 import org.acme.domain.ShortenedUrl;
 import org.jspecify.annotations.NonNull;
@@ -8,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Singleton
-@DefaultBean
+@IfBuildProfile("local")
 public class KafkaUrlPublisherLocal implements KafkaUrlPublisher {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/myurlshortner-be/src/main/resources/application-dev.properties
+++ b/myurlshortner-be/src/main/resources/application-dev.properties
@@ -5,17 +5,22 @@ quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=http://localhost:3000,http://localhost:80
 # Kafka
 kafka.bootstrap.servers=localhost:9092
-mp.messaging.outgoing.shortened-url-events.apicurio.registry.url=http://localhost:8901
-mp.messaging.outgoing.shortened-url-events.apicurio.registry.auto-register=false
-mp.messaging.outgoing.shortened-url-events.apicurio.registry.artifact-resolver-strategy=io.apicurio.registry.serde.avro.strategy.RecordIdStrategy
-mp.messaging.outgoing.shortened-url-events.apicurio.registry.artifact.group-id=com.acme.events
-mp.messaging.outgoing.shortened-url-events.apicurio.registry.artifact.version=1
-mp.messaging.outgoing.shortened-url-events.connector=smallrye-kafka
-mp.messaging.outgoing.shortened-url-events.topic=shortened-url-events
-mp.messaging.outgoing.shortened-url-events.value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer
+
+# Kafka UserAccessedShortenedUrl event producer for 'shortened-url-events' topic
+mp.messaging.outgoing.user-accessed-shortened-url.apicurio.registry.url=http://localhost:8901
+mp.messaging.outgoing.user-accessed-shortened-url.apicurio.registry.auto-register=false
+mp.messaging.outgoing.user-accessed-shortened-url.apicurio.registry.artifact-resolver-strategy=io.apicurio.registry.serde.avro.strategy.RecordIdStrategy
+mp.messaging.outgoing.user-accessed-shortened-url.apicurio.registry.artifact.group-id=com.acme.events
+mp.messaging.outgoing.user-accessed-shortened-url.apicurio.registry.artifact.version=1
+mp.messaging.outgoing.user-accessed-shortened-url.connector=smallrye-kafka
+mp.messaging.outgoing.user-accessed-shortened-url.topic=shortened-url-events
+mp.messaging.outgoing.user-accessed-shortened-url.value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer
 # If partitions > 1, make sure to assign unique value as key.
 #mp.messaging.outgoing.shortened-url-events.key=unique_identifier
-#mp.messaging.outgoing.shortened-url-events.key.serializer=unique_identifier
+#mp.messaging.outgoing.shortened-url-events.key.serializer=
 #mp.messaging.outgoing.shortened-url-events.value.deserializer=io.apicurio.registry.serde.avro.AvroKafkaDeserializer
+
+# Kafka <event-name> event producer for 'shortened-url-events' topic
+
 # Url Shortner
 app.hostname=localhost


### PR DESCRIPTION
#6 Fixes the issue regarding having specific schema in a topic, by creating a consumer for every event instead for every topic, we can send any event into a topic